### PR TITLE
build(emscripten): omit unix/posix-poll.c for emscripten targets

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -456,7 +456,6 @@ const emscripten_sources: []const []const u8 = &.{
     "unix/no-fsevents.c",
     "unix/no-proctitle.c",
     "unix/posix-hrtime.c",
-    "unix/posix-poll.c",
 };
 
 const haiku_sources: []const []const u8 = &.{


### PR DESCRIPTION
This change removes `unix/posix-poll.c` from the Emscripten source list. The file provides the POSIX-based implementation of `uv__io_poll()`, which is not directly usable in Emscripten's event-driven WASM environment. So, excluding it allows Emscripten targets to provide their own platform specific implementation of `uv__io_poll()` without symbol conflicts.